### PR TITLE
feat(KUI-1283): add support for fallback to kth-style 9 cortina blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@kth/api-call": "^4.0.40",
         "@kth/kth-node-passport-oidc": "^5.0.5",
         "@kth/kth-node-response": "^1.0.7",
-        "@kth/kth-node-web-common": "^9.0.1",
+        "@kth/kth-node-web-common": "^9.2.0",
         "@kth/kth-reactstrap": "^0.4.78",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.2.1",
@@ -3283,11 +3283,11 @@
       }
     },
     "node_modules/@kth/cortina-block": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@kth/cortina-block/-/cortina-block-5.1.0.tgz",
-      "integrity": "sha512-4jdjnlRL0CQ+LCoqGABmjIyz3oKoXKHJDMDeGpxfMg+DrLVysK079PSqUqxGRrccNcj44ctGt6BdKUUkPAcSMg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@kth/cortina-block/-/cortina-block-5.1.1.tgz",
+      "integrity": "sha512-ljLownpz7rPvkb5lamNaAhKKpwfmoQ30l4MJvT3E1Sq4wJvmVyi6oQCOlyWbKT6v91Fbkb9BM2E4nDFrzShVRg==",
       "dependencies": {
-        "@kth/log": "^4.0.5",
+        "@kth/log": "^4.0.7",
         "cheerio": "^1.0.0-rc.12"
       },
       "peerDependencies": {
@@ -3366,16 +3366,16 @@
       "integrity": "sha512-iXRZLTSaIpuGEvZ7no9KUEp2+YATyuqdm72kglxGJCXRwIFhBDLRb9rHgUkuxu8fhhNtv8nH7F9v4Q2HhJL/cw=="
     },
     "node_modules/@kth/kth-node-web-common": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@kth/kth-node-web-common/-/kth-node-web-common-9.0.1.tgz",
-      "integrity": "sha512-ibg49XDtATxsyeUM3NayF29jLwfTJURPAuYB3u7Zhs0PAQ2oPX2iOFvabLD/cqQxBxcqEr4yzlHphlMovCEerQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@kth/kth-node-web-common/-/kth-node-web-common-9.2.0.tgz",
+      "integrity": "sha512-mjTPxreqwP1C/htWdJ63l9oHeTvJJjx70Z4qeYm1+DTEPZpEZK1tSEr+ZrmfIqiQHQM4sBGURaIwRqTmnd1vDg==",
       "dependencies": {
-        "@kth/cortina-block": "^5.1.0",
-        "@kth/log": "^4.0.5",
+        "@kth/cortina-block": "^5.1.1",
+        "@kth/log": "^4.0.7",
         "entities": "^2.2.0",
-        "handlebars": "^4.7.7",
-        "kth-node-i18n": "^1.0.15",
-        "kth-node-redis": "^3.1.43",
+        "handlebars": "^4.7.8",
+        "kth-node-i18n": "^1.0.18",
+        "kth-node-redis": "^3.3.0",
         "locale": "^0.1.0"
       }
     },
@@ -14737,9 +14737,9 @@
       "integrity": "sha512-REBonWY8QD9xv5/VwpKcD/WBR0BtmdlSxum2uiJFbeebBGGXaWsiSltV8OpBnI0235Pu3i4aVboXBM3HY5NEuw=="
     },
     "node_modules/kth-node-redis": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/kth-node-redis/-/kth-node-redis-3.2.0.tgz",
-      "integrity": "sha512-Aoc0lNR9h7pUmh1wNZyRAixUToxeTg7fBOqhPcWHyiF4wseOc4fbzaNp75dDCGl57mJsHnTFjExVLyuf2vElww==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/kth-node-redis/-/kth-node-redis-3.3.0.tgz",
+      "integrity": "sha512-FDc3bLy0f1XYvKrKgY7m/Vj8l1kBHBNi3endMz1PIQka2U8ynVCIsNYNSqryHksF/6p5xRivvnryTIHnowdEMg==",
       "dependencies": {
         "@kth/log": "^4.0.7",
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@kth/api-call": "^4.0.40",
     "@kth/kth-node-passport-oidc": "^5.0.5",
     "@kth/kth-node-response": "^1.0.7",
-    "@kth/kth-node-web-common": "^9.0.1",
+    "@kth/kth-node-web-common": "^9.2.0",
     "@kth/kth-reactstrap": "^0.4.78",
     "@kth/log": "^4.0.7",
     "@kth/monitor": "^4.2.1",

--- a/server/server.js
+++ b/server/server.js
@@ -209,6 +209,7 @@ server.use(
     globalLink: config.blockApi.globalLink,
     addBlocks: config.blockApi.addBlocks,
     redisKey: config.cache.cortinaBlock.redisKey,
+    useStyle10: false,
   })
 )
 


### PR DESCRIPTION
Upgrade @kth/kth-node-web-common to 9.2.0 that adds support for fallback to kth-style 9 Cortina blocks.