### PR TITLE
cleanup local env setup and rename api env variables

### DIFF
--- a/.azure/prod.parameters.json
+++ b/.azure/prod.parameters.json
@@ -8,7 +8,7 @@
     "secretNames": {
       "value": [
         "ANALYSES_STORAGE_URL",
-        "API_KEY",
+        "KURSINFO_API_KEY",
         "APPLICATIONINSIGHTS_CONNECTION_STRING",
         "BLOB_SERVICE_SAS_URL",
         "OIDC_APPLICATION_ID",
@@ -25,7 +25,7 @@
     },
     "environmentVariables": {
       "value": {
-        "API_URI": "https://api.kth.se/api/kursinfo?defaultTimeout=10000",
+        "KURSINFO_API_URI": "https://api.kth.se/api/kursinfo?defaultTimeout=10000",
         "CAS_SSO_URI": "https://login.kth.se",
         "CM_HOST_URL": "https://www.kth.se/cm/",
         "CONSOLE_ENABLED": "false",

--- a/.azure/ref.parameters.json
+++ b/.azure/ref.parameters.json
@@ -8,7 +8,7 @@
     "secretNames": {
       "value": [
         "ANALYSES_STORAGE_URL",
-        "API_KEY",
+        "KURSINFO_API_KEY",
         "APPLICATIONINSIGHTS_CONNECTION_STRING",
         "BLOB_SERVICE_SAS_URL",
         "OIDC_APPLICATION_ID",
@@ -25,7 +25,7 @@
     },
     "environmentVariables": {
       "value": {
-        "API_URI": "https://api-r.referens.sys.kth.se/api/kursinfo?defaultTimeout=10000",
+        "KURSINFO_API_URI": "https://api-r.referens.sys.kth.se/api/kursinfo?defaultTimeout=10000",
         "CM_HOST_URL": "https://www-r.referens.sys.kth.se/cm/",
         "CONSOLE_ENABLED": "false",
         "KOPPS_URI": "https://api-r.referens.sys.kth.se/api/kopps/v2/?defaultTimeout=60000",

--- a/.env.in
+++ b/.env.in
@@ -1,7 +1,7 @@
-API_KEY=[key you specified in kursinfo-api for this service]
+KURSINFO_API_KEY=[key you specified in kursinfo-api for this service]
 APPLICATIONINSIGHTS_CONNECTION_STRING=<Available at Azure key vault>
 KOPPS_URI=https://api-r.referens.sys.kth.se/api/kopps/v2/?defaultTimeout=60000
-API_URI=<Available at Azure configuration page>
+KURSINFO_API_URI=<Available at Azure configuration page>
 SESSION_SECRET=[something random]
 SESSION_KEY=kursinfo-admin-web.sid
 OIDC_APPLICATION_ID=<FROM ADFS>

--- a/.env.in
+++ b/.env.in
@@ -1,19 +1,5 @@
-KURSINFO_API_KEY=[key you specified in kursinfo-api for this service]
-APPLICATIONINSIGHTS_CONNECTION_STRING=<Available at Azure key vault>
-KOPPS_URI=https://api-r.referens.sys.kth.se/api/kopps/v2/?defaultTimeout=60000
-KURSINFO_API_URI=<Available at Azure configuration page>
-SESSION_SECRET=[something random]
-SESSION_KEY=kursinfo-admin-web.sid
-OIDC_APPLICATION_ID=<FROM ADFS>
-OIDC_CLIENT_SECRET=<FROM ADFS>
-OIDC_TOKEN_SECRET=<Random string>
-OIDC_CONFIGURATION_URL=<not needed if localhost>
-OIDC_CALLBACK_URL=<not needed if localhost>
-OIDC_CALLBACK_SILENT_URL=<not needed if localhost>
-OIDC_CALLBACK_LOGOUT_URL=<not needed if localhost>
-REDIS_URI=[connection string to redis]
-BLOB_SERVICE_SAS_URL=https://[common storage name].blob.core.windows.net/?[params]&spr=https&sig=[generated signature]
-STORAGE_CONTAINER_NAME=kursinfo-image-container
-/*If you want to start your server on another port, add the following two variables, else use default ones from serversettings.js*/
-SERVER_PORT=[your port for the server]
-SERVER_HOST_URL=http://localhost:[SERVER_PORT]
+KURSINFO_API_KEY=[Available in Azure KeyVault]
+OIDC_APPLICATION_ID=[Available in Azure KeyVault]
+OIDC_CLIENT_SECRET=[Available in Azure KeyVault]
+REDIS_URI=[Available in Azure KeyVault]
+BLOB_SERVICE_SAS_URL=[Available in Azure KeyVault]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ localhost:3000/kursinfoadmin/kurser/kurs/:courseCode
 ```
 
 - Course introduction text for course information page, which can be edited by course coordinators and examiners.
-  (requires only: `KURSINFO_API_KEY` kursinfo-api)
 
 ```
 localhost:3000/kursinfoadmin/kurser/kurs/edit/:courseCode
@@ -97,31 +96,7 @@ Later you will use it as a _BLOB_SERVICE_SAS_URL_ in secrets together with a nam
 
 ### Secrets for Development
 
-Secrets during local development are ALWAYS stored in a `.env`-file in the root of your project.
-
-IMPORTANT: In Prod env, save URL:s in docker file but secrets in secrets.env
-
-```
-KURSINFO_API_KEY=[key you specified in kursinfo-api for this service]
-KOPPS_URI=https://[kopps api]/api/kopps/v2/?defaultTimeout=60000
-SESSION_SECRET=[something random]
-SESSION_KEY=[f.e. kursinfo-admin-web.sid]
-OIDC_APPLICATION_ID=<FROM ADFS>
-OIDC_CLIENT_SECRET=<FROM ADFS>
-OIDC_TOKEN_SECRET=<Random string>
-OIDC_CONFIGURATION_URL=<not needed if localhost>
-OIDC_CALLBACK_URL=<not needed if localhost>
-OIDC_CALLBACK_SILENT_URL=<not needed if localhost>
-OIDC_CALLBACK_LOGOUT_URL=<not needed if localhost>
-REDIS_URI=[connection string to redis]
-/*If you want to start your server on another port, add the following two variables, else use default ones from serversettings.js*/
-SERVER_PORT=[your port for the server]
-SERVER_HOST_URL=http://localhost:[SERVER_PORT]
-BLOB_SERVICE_SAS_URL=https://[blob storage address]/?sv=[date]&ss=b&srt=o&sp=rwcx&se=[date]&st=[date]&spr=https&sig=[generated signature]
-STORAGE_CONTAINER_NAME=kursinfo-image-container
-```
-
-These settings are also available in an `env.in` file.
+Secrets during local development are stored in a gitignored `.env` file (`env.in` can be used as template for your `.env` file). More details about environment variable setup and secrets can be found in [confluence](https://confluence.sys.kth.se/confluence/x/OYKBDQ).
 
 ### Install
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ localhost:3000/kursinfoadmin/kurser/kurs/:courseCode
 ```
 
 - Course introduction text for course information page, which can be edited by course coordinators and examiners.
-  (requires only: `API_KEY` kursinfo-api)
+  (requires only: `KURSINFO_API_KEY` kursinfo-api)
 
 ```
 localhost:3000/kursinfoadmin/kurser/kurs/edit/:courseCode
@@ -102,7 +102,7 @@ Secrets during local development are ALWAYS stored in a `.env`-file in the root 
 IMPORTANT: In Prod env, save URL:s in docker file but secrets in secrets.env
 
 ```
-API_KEY=[key you specified in kursinfo-api for this service]
+KURSINFO_API_KEY=[key you specified in kursinfo-api for this service]
 KOPPS_URI=https://[kopps api]/api/kopps/v2/?defaultTimeout=60000
 SESSION_SECRET=[something random]
 SESSION_KEY=[f.e. kursinfo-admin-web.sid]
@@ -206,7 +206,7 @@ npm run test
 
 ## Use 🐳
 
-`API_URI` in `docker-compose.yml` is configured for a local kursinfo-api, and might as well be changed to kursinfo-api in ref.
+`KURSINFO_API_URI` in `docker-compose.yml` is configured for a local kursinfo-api, and might as well be changed to kursinfo-api in ref.
 
 ```sh
 docker-compose up

--- a/config/serverSettings.js
+++ b/config/serverSettings.js
@@ -56,7 +56,7 @@ module.exports = {
 
   // API keys
   apiKey: {
-    kursinfoApi: getEnv('API_KEY', devDefaults('1234')),
+    kursinfoApi: getEnv('KURSINFO_API_KEY', devDefaults('1234')),
   },
 
   // Authentication
@@ -70,7 +70,7 @@ module.exports = {
 
   // Service API's
   nodeApi: {
-    kursinfoApi: unpackNodeApiConfig('API_URI', devKursinfoApi),
+    kursinfoApi: unpackNodeApiConfig('KURSINFO_API_URI', devKursinfoApi),
   },
 
   redisOptions: unpackRedisConfig('REDIS_URI', devRedis), // TODO, CHECK IF IT IS NEEDED

--- a/config/serverSettings.js
+++ b/config/serverSettings.js
@@ -20,7 +20,7 @@ const { safeGet } = require('safe-utils')
 const devPort = devDefaults(3000)
 const devSsl = devDefaults(false)
 const devUrl = devDefaults('http://localhost:' + devPort)
-const devKursinfoApi = devDefaults('http://localhost:3001/api/kursinfo?defaultTimeout=10000') // required=true&
+const devKursinfoApi = devDefaults('https://api-r.referens.sys.kth.se/api/kursinfo?defaultTimeout=10000') // required=true&
 const devKoppsApi = devDefaults('https://api-r.referens.sys.kth.se/api/kopps/v2/?defaultTimeout=60000') // required=true&
 const devSessionKey = devDefaults('kursinfo-admin-web.sid')
 const devSessionUseRedis = devDefaults(true)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       LOGGING_ACCESS_LOG: "true"
 
       # API runs on host
-      API_URI: "http://host.docker.internal:3001/api/kursinfo"
+      KURSINFO_API_URI: "http://host.docker.internal:3001/api/kursinfo"
 
       # API runs in ref
       KOPPS_URI: "https://api-r.referens.sys.kth.se/api/kopps/v2/?defaultTimeout=60000"


### PR DESCRIPTION
* cleanup local env setup 
* rename env variables for KursinfoAPI to include Kursinfo in the name (eg API_URI -> KURSINFO_API_URI)

https://kth-se.atlassian.net/browse/KUI-1316