### PR TITLE
chore(KUI-1907): fix brace-expansion vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6018,9 +6018,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9209,9 +9210,10 @@
       }
     },
     "node_modules/express-handlebars/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "docker:run": "bash ./docker-run-image.sh dev",
     "docker:start-dev": "npm run docker:build && npm run docker:run",
     "//": "Gulp installs css and javascript",
-    "prepare": "husky install",
+    "prepare": "husky",
     "lint": "eslint \"{public,server}/**/*.{js,jsx}\"",
     "test": "npx cross-env NODE_ENV=test jest test --passWithNoTests",
     "test-file": "cross-env NODE_ENV=test jest test ./test/CourseDescriptionEditor --watch",


### PR DESCRIPTION
I dismissed [this vulnerability](https://github.com/KTH/kursinfo-admin-web/security/dependabot/64) because we only ever use gulp during development or in the pipeline. There's no way for a malicious user to inject malicious stuff.