### PR TITLE
fix(KUI-1968): handle memberOf being undefined

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -169,8 +169,8 @@ const oidc = new OpenIDConnect(server, passport, {
 
     user.kthId = kthid
 
-    user.isSuperUser = memberOf.includes(config.auth.superuserGroup)
-    user.isKursinfoAdmin = memberOf.includes(config.auth.kursinfoAdmins)
+    user.isSuperUser = memberOf?.includes(config.auth.superuserGroup)
+    user.isKursinfoAdmin = memberOf?.includes(config.auth.kursinfoAdmins)
 
     user.memberOf = typeof memberOf === 'string' ? [memberOf] : memberOf
   },


### PR DESCRIPTION
Turns out our apps can't handle when `membersOf` is undefined. This is the case for people that lack membership in any group linked to _the old_ authorization of the admin apps. 

It was found in prod and could be re-created locally by first putting `memberOf` to undefined, giving the same error message as in the production logs for eg. `kursinfo-admin-web` when the request timed out:

```
2025-08-25T09:20:23.8835016Z {"name":"kursinfo-admin-web","hostname":"616b70db3ffa","pid":1,"level":50,"msg":"unhandledRejection kursinfo-admin-web TypeError: Cannot read properties of undefined (reading 'includes')\n at extendUser (/application/server/server.js:172:33)\n at createUserFromClaims (/application/node_modules/@kth/kth-node-passport-oidc/lib/oidc.js:82:25)\n at OpenIDConnectStrategy._verify (/application/node_modules/@kth/kth-node-passport-oidc/lib/oidc.js:210:11)\n at /application/node_modules/openid-client/lib/passport_strategy.js:174:10\n at process.processTicksAndRejections (node:internal/process/task_queues:95:5)","time":"2025-08-25T09:20:23.883Z","v":0}
```

With this fix the user should be faced with this when trying to access the admin pages (without access):

<img width="1814" height="1012" alt="image" src="https://github.com/user-attachments/assets/bee0ac7c-a942-4d70-8f13-3e930c3dcf2e" />

