### PR TITLE
KUI-2037: fix bug where course title is [object Object]

### DIFF
--- a/server/apiCalls/ladokApi.js
+++ b/server/apiCalls/ladokApi.js
@@ -13,7 +13,7 @@ async function getLadokCourseData(courseCode, lang) {
     mainSubject: huvudomraden?.[0].name,
     courseTitleData: {
       courseCode: kod,
-      courseTitle: benamning,
+      courseTitle: benamning.name,
       courseCredits: omfattning.formattedWithUnit,
       schoolCode,
     },


### PR DESCRIPTION
## 📌 Summary

<!-- Explain what this PR does and why. Link issues if relevant. -->

Fixes https://kth-se.atlassian.net/browse/KUI-2037

---

## 🔍 Changes

- Fetching course title using .benamning.name instead of .benamning

---

## ✅ Checklist (Author)

- [x] Code builds locally without errors
- [x] Tests added/updated and passing
- [x] Linting/formatting applied
- [x] No sensitive data in the diff
- [x] No stray console.logs in the diff
- [x] No stray comments in the diff
- [x] Docs/README/CHANGELOG updated (if needed)
- [x] Sufficient logging
- [x] Errors are handled accordingly

---

## 🧪 Testing & Verification

1. Made sure course title is no longer [object Object]
2. Ran test suite

Screenshots / recordings (if UI change):

---

## ⚠️ Impact / Risks

---

## 🚧 Out of Scope

---

## 📦 Downstream apps
