### PR TITLE
fix(8075): error thrown if searched course was avvecklad

### DIFF
--- a/server/apiCalls/ladokApi.js
+++ b/server/apiCalls/ladokApi.js
@@ -9,7 +9,7 @@ const HTTP_CODE_400 = 400
 
 async function getLadokCourseData(courseCode, lang) {
   const client = createApiClient(serverConfig.ladokMellanlagerApi)
-  const course = await client.getLatestCourseVersion(courseCode, lang)
+  const course = await client.getLatestCourseVersionIncludingCancelled(courseCode, lang)
   const { apiError, huvudomraden, benamning, kod, schoolCode, omfattning, statusCode } = course
 
   if (statusCode >= HTTP_CODE_400 || apiError) {


### PR DESCRIPTION
PR for this issue found during deployment [8075](https://dev.azure.com/kthse/KTH-DP-UTB/_workitems/edit/8075)

This was due to using normal GetLatestCourseVersion which does not include avvecklade courses. This fix is to make sure that we can include the avvecklade ones as well